### PR TITLE
グラフのズーム制御とクリック時につながっているノードの強調

### DIFF
--- a/src/components/vis/ForceGraphWrapper.jsx
+++ b/src/components/vis/ForceGraphWrapper.jsx
@@ -5,6 +5,7 @@ import DrawCircle from "./DrawCircle";
 
 const ForceGraphWrapper = ({ data, height, clicknode, setClicknode }) => {
   const fgRef = useRef();
+  const maxZoom = 3;
 
   const configureGraph = (fgRef) => {
     if (fgRef.current) {
@@ -12,6 +13,15 @@ const ForceGraphWrapper = ({ data, height, clicknode, setClicknode }) => {
       fgRef.current.d3Force("x", d3.forceX(0).strength(0.05));
       fgRef.current.d3Force("y", d3.forceY(0).strength(0.05));
       fgRef.current.d3Force("charge").strength(-100);
+
+      const zoom = d3.zoom().scaleExtent([0.1, maxZoom]);
+      d3.select(fgRef.current.canvas)
+        .call(zoom)
+        .on("wheel", (event) => {
+          if (event.deltaY < 0 && fgRef.current.zoom() >= maxZoom) {
+            event.preventDefault();
+          }
+        });
     }
   };
 
@@ -21,8 +31,9 @@ const ForceGraphWrapper = ({ data, height, clicknode, setClicknode }) => {
 
   useEffect(() => {
     if (clicknode && fgRef.current) {
+      const targetZoom = Math.min(2, maxZoom);
       fgRef.current.centerAt(clicknode.x - 100, clicknode.y, 1000);
-      fgRef.current.zoom(2, 1000);
+      fgRef.current.zoom(targetZoom, 1000);
     }
   }, [clicknode]);
 
@@ -33,7 +44,6 @@ const ForceGraphWrapper = ({ data, height, clicknode, setClicknode }) => {
     [setClicknode]
   );
 
-  // クリックされたノードに直接つながっているノードのIDを保存するセット
   const connectedNodeIds = useMemo(() => {
     if (!clicknode) return new Set();
     return new Set(
@@ -52,12 +62,14 @@ const ForceGraphWrapper = ({ data, height, clicknode, setClicknode }) => {
       graphData={data}
       width={window.innerWidth * 0.6}
       height={height}
+      maxZoom={maxZoom}
       nodeCanvasObject={(node, ctx, globalScale) => {
         const isConnected =
           clicknode &&
           (node.id === clicknode.id || connectedNodeIds.has(node.id));
+
         const size = (isConnected ? 8 : 5) / globalScale;
-        // const size = isConnected ? 8 : 5;
+
         const color = node.filter === 0 ? "hsl(240 50% 85%)" : "blue";
         const nodeColor = node.id === clicknode?.id ? "red" : color;
         DrawCircle(
@@ -78,14 +90,6 @@ const ForceGraphWrapper = ({ data, height, clicknode, setClicknode }) => {
           return 5;
         return 1;
       }}
-      // linkColor={(link) => {
-      //   if (
-      //     clicknode &&
-      //     (link.source.id === clicknode.id || link.target.id === clicknode.id)
-      //   )
-      //     return "red";
-      //   return "rgba(200, 200, 200, 0.5)";
-      // }}
     />
   );
 };


### PR DESCRIPTION
ある一定以上ズームできないようにしました。
クリック時につながっているノードを以下の方法で強調しました。

1. つながっているリンクを太くする
2. つがっているノードを大きくする
3. 輪郭を色をつける