### PR TITLE
曲詳細に画面においてスクロールバーの有無でバツボタンの位置が変わるのを修正

### DIFF
--- a/src/components/vis/NodeInfo/NodeInfo.jsx
+++ b/src/components/vis/NodeInfo/NodeInfo.jsx
@@ -12,7 +12,7 @@ const StyledPaper = styled(Paper)(({ theme }) => ({
   left: "10px",
   width: "400px",
   height: "calc(100vh - 140px)",
-  overflowY: "auto",
+  overflowY: "scroll",
 }));
 
 const NodeInfo = ({ node, Data, setClicknode }) => {


### PR DESCRIPTION
<span>
<img width="200" alt="スクリーンショット 2024-09-19 1 09 10" src="https://github.com/user-attachments/assets/964cc18f-0f29-401a-9883-1dfda353a29f">
<img width="200" alt="スクリーンショット 2024-09-19 1 09 21" src="https://github.com/user-attachments/assets/1416a857-0a5f-4844-a1a8-f17ebab4898c">
</span>

バツボタンの位置がスクロールの有無で位置が変わるのを修正しました。