### PR TITLE
Changed to always display the title and Buttons in the song detail screen.

### DIFF
--- a/src/components/vis/NodeInfo/BasicInfomation.jsx
+++ b/src/components/vis/NodeInfo/BasicInfomation.jsx
@@ -6,38 +6,64 @@ import { durationFormat } from "@/utils/calcTime";
 
 const StyledIconButton = styled(IconButton)(({ theme }) => ({
   position: "absolute",
-  top: "5px",
-  right: "5px",
+  top: "8px",
+  right: "12px",
+  color: "rgba(0, 0, 0, 0.3)",
+  transition: "color 0.2s ease",
+  "&:hover": {
+    color: "rgba(0, 0, 0, 0.87)",
+  },
 }));
 
-const BasicInfomation = ({ node, onClose }) => {
+const FixedHeader = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "showBorder",
+})(({ showBorder }) => ({
+  position: "sticky",
+  top: 0,
+  backgroundColor: "white",
+  zIndex: 1,
+  padding: "12px 16px",
+  paddingBottom: "4px",
+  transition: "border-bottom 0.3s ease",
+  borderBottom: showBorder ? "1px solid rgba(0, 0, 0, 0.12)" : "none",
+}));
+
+const TitleBox = styled(Box)({
+  marginTop: 0,
+});
+
+const ScrollableContent = styled(Box)({
+  padding: "16px",
+  paddingTop: "4px",
+});
+
+const BasicInfomation = ({ node, onClose, showBorder }) => {
   return (
     <>
-      <Box p={2} position="relative">
+      <FixedHeader showBorder={showBorder}>
         <StyledIconButton onClick={onClose}>
           <CloseIcon />
         </StyledIconButton>
-        <Box mt={5}>
+        <TitleBox>
           <Typography variant="body">{node.composer}</Typography>
-          <Typography variant="h6" gutterBottom>
+          <Typography variant="h6" gutterBottom sx={{ marginBottom: 1 }}>
             {node.title}
           </Typography>
-          <Typography variant="body2" color="textSecondary" gutterBottom>
-            {node.duration === null
-              ? ""
-              : "演奏時間: " + durationFormat(node.duration)}
-          </Typography>
-          <Typography variant="body2" color="textSecondary" gutterBottom>
-            {node.workFormulaStr === ""
-              ? ""
-              : "楽器編成: " + node.workFormulaStr.replace(/\n/g, " / ")}
-          </Typography>
-        </Box>
-        <SplitButton
-          workId={node.id}
-          node={node}
-        />
-      </Box>
+        </TitleBox>
+      </FixedHeader>
+      <ScrollableContent>
+        <Typography variant="body2" color="textSecondary" gutterBottom>
+          {node.duration === null
+            ? ""
+            : "演奏時間: " + durationFormat(node.duration)}
+        </Typography>
+        <Typography variant="body2" color="textSecondary" gutterBottom>
+          {node.workFormulaStr === ""
+            ? ""
+            : "楽器編成: " + node.workFormulaStr.replace(/\n/g, " / ")}
+        </Typography>
+        <SplitButton workId={node.id} node={node} />
+      </ScrollableContent>
     </>
   );
 };

--- a/src/components/vis/NodeInfo/NodeInfo.jsx
+++ b/src/components/vis/NodeInfo/NodeInfo.jsx
@@ -1,5 +1,5 @@
-import React, { useCallback } from "react";
-import { Paper, Divider } from "@mui/material";
+import React, { useCallback, useState } from "react";
+import { Paper, Divider, Box } from "@mui/material";
 import { styled } from "@mui/system";
 import BasicInfomation from "./BasicInfomation";
 import DetailInfomation from "./DetailInfomation";
@@ -17,16 +17,26 @@ const StyledPaper = styled(Paper)(({ theme }) => ({
 
 const NodeInfo = (props) => {
   const { Data, node, setClickedNodeId } = props;
+  const [isScrolled, setIsScrolled] = useState(false);
+
   const handleCloseInfo = useCallback(() => {
     setClickedNodeId(null);
   }, [setClickedNodeId]);
+
+  const handleScroll = (e) => {
+    setIsScrolled(e.target.scrollTop > 10);
+  };
 
   if (!node) return null;
 
   return (
     <div>
-      <StyledPaper key={node.id}>
-        <BasicInfomation node={node} onClose={handleCloseInfo} />
+      <StyledPaper key={node.id} onScroll={handleScroll}>
+        <BasicInfomation
+          node={node}
+          onClose={handleCloseInfo}
+          showBorder={isScrolled}
+        />
         <Divider />
         <DetailInfomation node={node} />
         <Divider />


### PR DESCRIPTION
<img width="300" alt="スクリーンショット 2024-10-22 13 28 52" src="https://github.com/user-attachments/assets/8099d471-f35b-4dbb-925e-2cee7f24d905">
<img width="600" alt="スクリーンショット 2024-10-22 13 29 25" src="https://github.com/user-attachments/assets/9dd73c55-fce0-4e9c-a8e2-fb3e158ab25a">

曲詳細画面をスクロール時にタイトルがわからなくなることがあるのでそれに対応するため常にタイトルを表示するように変更した。

This pull request includes several updates to the `NodeInfo` component to improve its UI and functionality. The most important changes include adding a scroll listener to toggle a border, refactoring the component structure for better readability, and updating the styling for various elements.

### UI and functionality improvements:

* [`src/components/vis/NodeInfo/NodeInfo.jsx`](diffhunk://#diff-430c38c70e7449404a44c6e87d51ab2ccd6a61613484935ccc50250c02b130a2R20-R39): Added a scroll listener to toggle the border of the `FixedHeader` component based on scroll position. Introduced a new state variable `isScrolled` to manage this behavior.
* [`src/components/vis/NodeInfo/BasicInfomation.jsx`](diffhunk://#diff-1a32befec0e7d0e8190a9b14ce3b4a51302020cb5517c96694a681e233c95800L9-R54): Refactored the component to include new styled components `FixedHeader`, `TitleBox`, and `ScrollableContent`. Updated the `StyledIconButton` styling to include a hover effect.

### Code refactoring:

* [`src/components/vis/NodeInfo/NodeInfo.jsx`](diffhunk://#diff-430c38c70e7449404a44c6e87d51ab2ccd6a61613484935ccc50250c02b130a2L1-R2): Added `useState` and `Box` imports.
* [`src/components/vis/NodeInfo/BasicInfomation.jsx`](diffhunk://#diff-1a32befec0e7d0e8190a9b14ce3b4a51302020cb5517c96694a681e233c95800L35-R66): Cleaned up the component structure by moving elements into `FixedHeader` and `ScrollableContent` components.