### PR TITLE
ツールチップの修正

### DIFF
--- a/src/components/vis/ForceGraphWrapper.jsx
+++ b/src/components/vis/ForceGraphWrapper.jsx
@@ -16,8 +16,8 @@ const ForceGraphWrapper = (props) => {
 
   const [tooltip, setTooltip] = useState({
     visible: false,
-    x: 0,
-    y: 0,
+    x: null,
+    y: null,
     content: "",
   });
 

--- a/src/components/vis/ForceGraphWrapper.jsx
+++ b/src/components/vis/ForceGraphWrapper.jsx
@@ -172,7 +172,9 @@ const ForceGraphWrapper = (props) => {
             padding: "5px 10px",
             borderRadius: "4px",
             pointerEvents: "none",
-            whiteSpace: "nowrap",
+            whiteSpace: "normal",
+            maxWidth: "300px",
+            wordBreak: "break-word",
             zIndex: 10,
           }}
         >

--- a/src/components/vis/ForceGraphWrapper.jsx
+++ b/src/components/vis/ForceGraphWrapper.jsx
@@ -111,7 +111,7 @@ const ForceGraphWrapper = (props) => {
       setTooltip({
         visible: true,
         x: x + 10,
-        y: y + 10,
+        y: window.innerHeight - y < 200 ? y - 30 : y + 10,
         content: node.name,
       });
     } else {

--- a/src/components/vis/ForceGraphWrapper.jsx
+++ b/src/components/vis/ForceGraphWrapper.jsx
@@ -110,7 +110,7 @@ const ForceGraphWrapper = (props) => {
       const { x, y } = fgRef.current.graph2ScreenCoords(node.x, node.y);
       setTooltip({
         visible: true,
-        x: x + 10,
+        x: window.innerWidth / 2 - x < 0 ? x - 150 : x + 10,
         y: window.innerHeight - y < 200 ? y - 30 : y + 10,
         content: node.name,
       });


### PR DESCRIPTION
画面ギリギリだとめちゃめちゃ折り返しされてしまうのを修正

Before
<img width="600" alt="スクリーンショット 2024-11-25 0 19 36" src="https://github.com/user-attachments/assets/64976dd7-cbcf-47b5-bf1d-85c71787955b">

After
<img width="600" alt="スクリーンショット 2024-11-25 0 18 26" src="https://github.com/user-attachments/assets/555f7ad5-0ff0-47e5-8fd1-9c7326004bf2">

This pull request includes several changes to the `ForceGraphWrapper` component to enhance its functionality and improve user experience. The most important changes include adding a tooltip feature for node hover events, fixing a minor color syntax issue, and ensuring proper cleanup of event handlers.

Enhancements to node interaction:

* [`src/components/vis/ForceGraphWrapper.jsx`](diffhunk://#diff-aaa5f8351c81fad8bf23c5210a937f48c8963f26e7ca3936020bf9e072e3902dL1-R7): Added `useState` to manage tooltip visibility and content.
* [`src/components/vis/ForceGraphWrapper.jsx`](diffhunk://#diff-aaa5f8351c81fad8bf23c5210a937f48c8963f26e7ca3936020bf9e072e3902dR108-R123): Implemented `handleNodeHover` callback to update tooltip position and content on node hover.
* [`src/components/vis/ForceGraphWrapper.jsx`](diffhunk://#diff-aaa5f8351c81fad8bf23c5210a937f48c8963f26e7ca3936020bf9e072e3902dR152): Added `onNodeHover` event handler to display tooltips and set `nodeLabel` and `linkLabel` to null to prevent default labels. [[1]](diffhunk://#diff-aaa5f8351c81fad8bf23c5210a937f48c8963f26e7ca3936020bf9e072e3902dR152) [[2]](diffhunk://#diff-aaa5f8351c81fad8bf23c5210a937f48c8963f26e7ca3936020bf9e072e3902dR161-R182)

Code improvements:

* [`src/components/vis/ForceGraphWrapper.jsx`](diffhunk://#diff-aaa5f8351c81fad8bf23c5210a937f48c8963f26e7ca3936020bf9e072e3902dL62-R75): Updated dependencies in `useEffect` to include `setClickedNodeId` for proper cleanup.