### PR TITLE
issues #118 曲詳細情報に共演度を追加

### DIFF
--- a/src/components/vis/DataProcessing.jsx
+++ b/src/components/vis/DataProcessing.jsx
@@ -46,6 +46,7 @@ export const processData = () => {
         distance: 100 / playedWith.amount,
         sourceData: getComposerFromId(work.workId),
         targetData: getComposerFromId(playedWith.workId),
+        amount: playedWith.amount,
       }))
   );
 
@@ -57,6 +58,7 @@ const createGraphNodes = (linkData) => {
   const uniqueNodes = Array.from(
     new Set(links.flatMap((link) => [link.source, link.target]))
   );
+
   return getWorksWithComposerDetails().filter((work) =>
     uniqueNodes.includes(work.id)
   );

--- a/src/components/vis/NodeInfo/BasicInfomation.jsx
+++ b/src/components/vis/NodeInfo/BasicInfomation.jsx
@@ -41,8 +41,6 @@ const ScrollableContent = styled(Box)({
 const BasicInfomation = ({ node, onClose, showBorder }) => {
   const workFormulaText = getWorkFormulaText(node.workFormula);
 
-  console.log(node);
-
   return (
     <>
       <FixedHeader showBorder={showBorder}>

--- a/src/components/vis/NodeInfo/SongPlayedTogether.jsx
+++ b/src/components/vis/NodeInfo/SongPlayedTogether.jsx
@@ -30,9 +30,7 @@ const SongPlayedTogether = (props) => {
   }
 
   const linkNodesArray = Array.from(linkNodes).sort((a, b) => {
-    const aAmount = a.amount ?? 0;
-    const bAmount = b.amount ?? 0;
-    return bAmount - aAmount;
+    return b.amount - a.amount;
   });
 
   if (linkNodesArray.length === 0) return;
@@ -80,18 +78,17 @@ const SongPlayedTogether = (props) => {
               {work.title}
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              {work.year === null ? "" : "作曲年: " + work.year + "年"}
-            </Typography>
-            <Typography variant="body2" color="text.secondary">
               {(() => {
                 if (work.amount == null) return "";
-                else if (work.amount === 2) return "共演度: ★☆☆";
-                else if (work.amount >= 3 && work.amount <= 4)
-                  return "共演度: ★★☆";
-                else if (work.amount >= 5) return "共演度: ★★★";
-                else return "☆☆☆";
+                else if (work.amount <= 2) return "共演度: ★☆☆";
+                else if (work.amount <= 4) return "共演度: ★★☆";
+                else return "共演度: ★★★";
               })()}
             </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {work.year === null ? "" : "作曲年: " + work.year + "年"}
+            </Typography>
+
             <Typography variant="body2" color="text.secondary">
               {work.duration === null
                 ? ""

--- a/src/components/vis/NodeInfo/SongPlayedTogether.jsx
+++ b/src/components/vis/NodeInfo/SongPlayedTogether.jsx
@@ -12,17 +12,30 @@ const SongPlayedTogether = (props) => {
   if (links != null && links.length !== 0) {
     links.forEach((link) => {
       if (link.source === node || link.target === node) {
-        linkNodes.add(link.source);
-        linkNodes.add(link.target);
+        linkNodes.add({
+          ...link.target,
+          amount: link.amount,
+        });
+        linkNodes.add({
+          ...link.source,
+          amount: link.amount,
+        });
       }
     });
-    linkNodes.delete(node);
+    for (const linkNode of linkNodes) {
+      if (linkNode.id === node.id) {
+        linkNodes.delete(linkNode);
+      }
+    }
   }
 
-  const linkNodesArray = Array.from(linkNodes);
+  const linkNodesArray = Array.from(linkNodes).sort((a, b) => {
+    const aAmount = a.amount ?? 0;
+    const bAmount = b.amount ?? 0;
+    return bAmount - aAmount;
+  });
 
   if (linkNodesArray.length === 0) return;
-
   return (
     <Box p={2}>
       <Typography variant="h6" gutterBottom>
@@ -30,7 +43,6 @@ const SongPlayedTogether = (props) => {
       </Typography>
       {linkNodesArray.map((work, index) => {
         const workFormulaText = getWorkFormulaText(work.workFormula);
-
         return (
           <Button
             key={index}
@@ -67,8 +79,18 @@ const SongPlayedTogether = (props) => {
             >
               {work.title}
             </Typography>
-            <Typography variant="body2" color="text.secondary" gutterBottom>
+            <Typography variant="body2" color="text.secondary">
               {work.year === null ? "" : "作曲年: " + work.year + "年"}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {(() => {
+                if (work.amount == null) return "";
+                else if (work.amount === 2) return "共演度: ★☆☆";
+                else if (work.amount >= 3 && work.amount <= 4)
+                  return "共演度: ★★☆";
+                else if (work.amount >= 5) return "共演度: ★★★";
+                else return "☆☆☆";
+              })()}
             </Typography>
             <Typography variant="body2" color="text.secondary">
               {work.duration === null


### PR DESCRIPTION
issues #118 

曲詳細情報に一緒に演奏された回数を用いて共演度を表示する

以下のような実装

一緒に演奏された回数が2回の時「★☆☆」
一緒に演奏された回数が3~4回の時「★★☆」
一緒に演奏された回数が5回以上の時「★★★」
また、よく一緒に演奏されている曲は一緒に演奏された回数が多い順にソートしておく