### PR TITLE
issues #91 #125 #126 #127 #128を実装

### DIFF
--- a/src/components/evaluation/Insights.jsx
+++ b/src/components/evaluation/Insights.jsx
@@ -20,22 +20,25 @@ import RectangularGraph from "@//components/evaluation/RectangularGraph.jsx";
 import { getWorkFormulaText } from "@/utils/getWorkFormulaText";
 
 export default function Insights(props) {
-  const { myConcert, handleClose, submitAction } = props;
+  const { myConcert, concertName, handleClose, submitAction } = props;
 
   if (!myConcert) {
     return <></>;
   }
 
-  const works = myConcert.works.map((workConcert) => {
+  const hasWorks = myConcert.works && myConcert.works.length > 0;
+
+  const works = hasWorks ? myConcert.works.map((workConcert) => {
     const work = workData.find((work) => work.id === workConcert.work);
-    return {
-      ...work,
-      composerData: composersData.find(
-        (composer) => composer.name === work.composer,
-      ),
-      selectedMovements: workConcert.movements,
-    };
-  });
+      return {
+        ...work,
+        composerData: composersData.find(
+          (composer) => composer.name === work.composer,
+        ),
+        selectedMovements: workConcert.movements,
+        };
+      })
+    : [];
 
   return (
     <Dialog
@@ -43,161 +46,178 @@ export default function Insights(props) {
       maxWidth="xl"
       open={true}
       onClose={handleClose}
-      sx={{ height: "calc(100% - 64px)" }}
+      sx={{ height: "100%" }}
     >
       <DialogTitle>
-        My演奏会{myConcert.title}
+        {concertName}
         {/* ToDo */}
       </DialogTitle>
       <DialogContent sx={{ height: "90vh" }}>
-        <Box
-          sx={{
-            height: "100%",
-            overflowX: "hidden",
-            display: "grid",
-            gridTemplateColumns: "1fr 1fr", // 左右2列
-            gridTemplateRows: "7fr 3fr", // 上下2行
-            gap: 1, // グリッド間のスペース
-          }}
-        >
-          <Box sx={{ height: "100%", overflowY: "auto", gridRow: "span 2" }}>
-            <Box>
-              {works.map((work, index) => {
-                const duration_time = durationFormat(
-                  !work.selectedMovements ||
-                    work.workMovementDuration.length <= 1 ||
-                    work.workMovementDuration[0] === "'"
-                    ? work.duration
-                    : work.selectedMovements
-                        .map((duration) =>
-                          parseInt(
-                            work.workMovementDuration[duration].replace(
-                              "'",
-                              "",
+        {hasWorks ? (
+          <Box
+            sx={{
+              height: "100%",
+              overflowX: "hidden",
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr", // 左右2列
+              gridTemplateRows: "7fr 3fr", // 上下2行
+              gap: 1, // グリッド間のスペース
+            }}
+          >
+            <Box sx={{ height: "100%", overflowY: "auto", gridRow: "span 2" }}>
+              <Box>
+                {works.map((work, index) => {
+                  const duration_time = durationFormat(
+                    !work.selectedMovements ||
+                      work.workMovementDuration.length <= 1 ||
+                      work.workMovementDuration[0] === "'"
+                      ? work.duration
+                      : work.selectedMovements
+                          .map((duration) =>
+                            parseInt(
+                              work.workMovementDuration[duration].replace(
+                                "'",
+                                "",
+                              ),
                             ),
-                          ),
-                        )
-                        .reduce((x, y) => x + y),
-                );
+                          )
+                          .reduce((x, y) => x + y),
+                  );
 
-                const workFormulaText = getWorkFormulaText(work.workFormula);
+                  const workFormulaText = getWorkFormulaText(work.workFormula);
 
-                return (
-                  <div key={`${myConcert.concert}-${index}`}>
-                    {index !== 0 && <Divider />}
-                    <Paper
-                      elevation={0}
-                      sx={{
-                        "&:hover": {
-                          backgroundColor: "action.hover",
-                        },
-                        cursor: "pointer",
-                      }}
-                    >
-                      <Grid
-                        container
-                        direction="row"
-                        justifyContent="space-between"
-                        alignItems="center"
-                        sx={{ width: "100%" }}
+                  return (
+                    <div key={`${myConcert.concert}-${index}`}>
+                      {index !== 0 && <Divider />}
+                      <Paper
+                        elevation={0}
+                        sx={{
+                          "&:hover": {
+                            backgroundColor: "action.hover",
+                          },
+                          cursor: "pointer",
+                        }}
                       >
-                        <Grid size="grow">
-                          <Box sx={{ p: 1 }}>
-                            <Typography variant="body1" component="div">
-                              {`${work.composer} ${
-                                work.composerData.birthYear ||
-                                work.composerData.deathYear
-                                  ? ` (${work.composerData.birthYear || ""}〜${work.composerData.deathYear || ""})`
-                                  : ""
-                              }`}
-                            </Typography>
-                            <Typography variant="h6" component="div">
-                              {work.title}
-                            </Typography>
+                        <Grid
+                          container
+                          direction="row"
+                          justifyContent="space-between"
+                          alignItems="center"
+                          sx={{ width: "100%" }}
+                        >
+                          <Grid size="grow">
+                            <Box sx={{ p: 1 }}>
+                              <Typography variant="body1" component="div">
+                                {`${work.composer} ${
+                                  work.composerData.birthYear ||
+                                  work.composerData.deathYear
+                                    ? ` (${work.composerData.birthYear || ""}〜${work.composerData.deathYear || ""})`
+                                    : ""
+                                }`}
+                              </Typography>
+                              <Typography variant="h6" component="div">
+                                {work.title}
+                              </Typography>
 
-                            <Typography variant="body2" color="text.secondary">
-                              {work.year === null
-                                ? ""
-                                : "作曲年: " + work.year + "年"}
-                            </Typography>
-                            <Typography variant="body2" color="text.secondary">
-                              {duration_time !== ""
-                                ? `演奏時間: ${duration_time}`
-                                : ""}
-                            </Typography>
-                            <Typography variant="body2" color="text.secondary">
-                              {workFormulaText
-                                ? "楽器編成: " + workFormulaText
-                                : ""}
-                            </Typography>
-                          </Box>
-                        </Grid>
-                      </Grid>
-                      <Grid size="grow">
-                        {work.selectedMovements.length > 0 && (
-                          <Stack
-                            direction="row"
-                            spacing={1}
-                            sx={{
-                              width: "100%",
-                              justifyContent: "space-between",
-                              alignItems: "center",
-                            }}
-                          >
-                            <Box sx={{ p: 1, overflowX: "auto" }}>
-                              <Stack direction="row" spacing={1}>
-                                {work.selectedMovements.map(
-                                  (movement, index) => (
-                                    <Chip
-                                      key={index}
-                                      label={work.workMovements[movement]}
-                                    />
-                                  ),
-                                )}
-                              </Stack>
+                              <Typography variant="body2" color="text.secondary">
+                                {work.year === null
+                                  ? ""
+                                  : "作曲年: " + work.year + "年"}
+                              </Typography>
+                              <Typography variant="body2" color="text.secondary">
+                                {duration_time !== ""
+                                  ? `演奏時間: ${duration_time}`
+                                  : ""}
+                              </Typography>
+                              <Typography variant="body2" color="text.secondary">
+                                {workFormulaText
+                                  ? "楽器編成: " + workFormulaText
+                                  : ""}
+                              </Typography>
                             </Box>
-                          </Stack>
-                        )}
-                      </Grid>
-                    </Paper>
-                  </div>
-                );
-              })}
+                          </Grid>
+                        </Grid>
+                        <Grid size="grow">
+                          {work.selectedMovements.length > 0 && (
+                            <Stack
+                              direction="row"
+                              spacing={1}
+                              sx={{
+                                width: "100%",
+                                justifyContent: "space-between",
+                                alignItems: "center",
+                              }}
+                            >
+                              <Box sx={{ p: 1, overflowX: "auto" }}>
+                                <Stack direction="row" spacing={1}>
+                                  {work.selectedMovements.map(
+                                    (movement, index) => (
+                                      <Chip
+                                        key={index}
+                                        label={work.workMovements[movement]}
+                                      />
+                                    ),
+                                  )}
+                                </Stack>
+                              </Box>
+                            </Stack>
+                          )}
+                        </Grid>
+                      </Paper>
+                    </div>
+                  );
+                })}
+              </Box>
+            </Box>
+            <Box
+              sx={{
+                height: "80%",
+                gridColumn: "2",
+                gridRow: "1",
+              }}
+            >
+              <Typography variant="h7" gutterBottom>
+                曲目構成の分析結果
+              </Typography>
+              <Radar works={works} />
+            </Box>
+            <Box
+              sx={{
+                height: "80%",
+                gridColumn: "2",
+                gridRow: "2",
+              }}
+            >
+              <Typography variant="h7" gutterBottom>
+                演奏時間の分析結果
+              </Typography>
+              <RectangularGraph works={works} />
             </Box>
           </Box>
+        ) : (
           <Box
             sx={{
-              height: "80%",
-              gridColumn: "2",
-              gridRow: "1",
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              height: "100%",
             }}
           >
-            <Typography variant="h7" gutterBottom>
-              曲目構成の分析結果
+            <Typography variant="body1" sx={{ fontSize: 20 }} align="center">
+              分析結果を表示するには1つ以上曲を追加してください
             </Typography>
-            <Radar works={works} />
           </Box>
-          <Box
-            sx={{
-              height: "80%",
-              gridColumn: "2",
-              gridRow: "2",
-            }}
-          >
-            <Typography variant="h7" gutterBottom>
-              演奏時間の分析結果
-            </Typography>
-            <RectangularGraph works={works} />
-          </Box>
-        </Box>
+        )}
       </DialogContent>
       <DialogActions>
         <Button variant="outlined" onClick={handleClose}>
           閉じる
         </Button>
-        <Button variant="contained" onClick={submitAction.func}>
-          {submitAction.label}
-        </Button>
+        {hasWorks && (
+          <Button variant="contained" onClick={submitAction.func}>
+            {submitAction.label}
+          </Button>
+        )}
       </DialogActions>
     </Dialog>
   );

--- a/src/components/evaluation/radarChart.jsx
+++ b/src/components/evaluation/radarChart.jsx
@@ -73,15 +73,16 @@ export function Radar(props) {
         return (
           <div
             style={{
-              background: "white",
-              padding: "9px 12px",
-              border: "1px solid #ccc",
+              padding: "12px 16px",
+              background: "#fff",
+              borderRadius: "4px",
+              boxShadow: "0 3px 9px rgba(0,0,0,0.25)",
             }}
           >
             <div>
               <strong>{slice.index}</strong>
             </div>
-            <div>{slice.data[0].value} 点</div>
+            <div>{slice.data[0].value.toFixed(1)} 点</div>
           </div>
         );
       }}

--- a/src/components/layouts/AddMyConcert.jsx
+++ b/src/components/layouts/AddMyConcert.jsx
@@ -112,8 +112,6 @@ export default function AddMyConcert(props) {
     return null; // work が null または workMovements が存在しない場合は何も表示しない
   }
 
-  console.log(work);
-
   return (
     <Modal
       open={open}

--- a/src/components/layouts/MyConcert/Card.jsx
+++ b/src/components/layouts/MyConcert/Card.jsx
@@ -62,6 +62,7 @@ export default function MyConcertCard(props) {
     <Card elevation={3}>
       <InsightsModal
         myConcert={InsightsWorks}
+        concertName={name}
         open={openInsight}
         setOpen={setOpenInsight}
       />

--- a/src/components/layouts/MyConcert/InsightsModal.jsx
+++ b/src/components/layouts/MyConcert/InsightsModal.jsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import Insights from "@/components/evaluation/Insights.jsx";
 
 export default function InsightsModal(props) {
-  const { myConcert, open, setOpen } = props;
+  const { myConcert, concertName, open, setOpen } = props;
 
   const { enqueueSnackbar } = useSnackbar();
 
@@ -34,6 +34,7 @@ export default function InsightsModal(props) {
   return (
     <Insights
       myConcert={myConcert}
+      concertName={concertName}
       handleClose={handleClose}
       submitAction={submitAction}
     />


### PR DESCRIPTION
issues #91 #125 #126 #127 #128 を実装した。

# 実装内容
## 評価画面のツールチップのデザインを統一する #91
以下のようにツールチップのスタイルを揃えました。
<img width="400" alt="スクリーンショット 2024-12-23 0 36 49" src="https://github.com/user-attachments/assets/741805c1-3503-41fe-a41a-62e582d7c400" />
<img width="400" alt="スクリーンショット 2024-12-23 0 36 59" src="https://github.com/user-attachments/assets/cc3b758d-e587-4085-82e7-1af24c7ca90f" />

## My演奏会に曲が追加されていないときの分析画面にテキストを追加 #125
My演奏会に曲が一曲も登録されていない時には「分析結果を表示するには1つ以上曲を追加してください」を表示
<img width="400" alt="スクリーンショット 2024-12-23 0 39 35" src="https://github.com/user-attachments/assets/331a3cd3-ea2e-4d1e-a338-ed9d81af78c4" />

## 分析画面のレダーチャートの点数 #126
ツールチップの点数を小数点第2位を四捨五入して小数第1位までで表示
<img width="400" alt="スクリーンショット 2024-12-23 0 36 49" src="https://github.com/user-attachments/assets/741805c1-3503-41fe-a41a-62e582d7c400" />

## 分析画面においてMy演奏会のタイトルが取れていない #127
演奏会のタイトルが取れていなかったので修正

## 分析画面のモーダルサイズ変じゃない #128
モーダルサイズを大きくしました。


