### PR TITLE
My演奏会内の曲をドラッグ＆ドロップしてすぐ曲をクリックすると、ノードがフォーカスされずにエラーが出るバグを修正

### DIFF
--- a/src/components/layouts/MyConcert/WorkList.jsx
+++ b/src/components/layouts/MyConcert/WorkList.jsx
@@ -74,7 +74,7 @@ export default function WorkList({ works, concertID, setClickedNodeId }) {
             <WorkListItem
               work={activeMyConcertWork}
               concertID={concertID}
-              setClicknode={setClickedNodeId}
+              setClickedNodeId={setClickedNodeId}
               setWorkConcertState={setWorkConcertState}
             />
           )}


### PR DESCRIPTION
1か所だけ残っていた"setClicknode"を"setClickedNodeId"に修正するだけでした